### PR TITLE
Updating tycho-jnlp-plugin for JAR files security features, required from jdk7u25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
   - oraclejdk8
-  - openjdk8

--- a/README.md
+++ b/README.md
@@ -26,4 +26,58 @@ jarsigner. This mojo signs all jars, regardless if they were built locally or
 came from third party artifact repository. This is necessary for Java Webstart, 
 which requires use of the same signature for all jars referenced from JNLP file. 
 This mojo honours most of properties used by maven-jarsigner-plugin 
-(${jarsigner.keystore}, ${jarsigner.storepass} and so on).
+(${jarsigner.keystore}, ${jarsigner.storepass} and so on). The property 
+${jarsigner.digestalg} must be set to SHA-1 when using a jarsigner form a JDK7 
+because the default signing algorithm is now SHA256.
+
+The [JAR File Manifest Attributes](http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html) 
+for Security can also be added to each jar file. The attributes can be configured
+by the properties :
+
+ * ${jarsigner.permissions} Permissions
+ * ${jarsigner.codebase} Codebase
+ * ${jarsigner.applicationName} Application-Name
+ * ${jarsigner.applicationLibraryAllowableCodebase} Application-Library-Allowable-Codebase
+ * ${jarsigner.callerAllowableCodebase} Caller-Allowable-Codebase
+ * ${jarsigner.trustedOnly} Trusted-Only
+ * ${jarsigner.trustedLibrary} Trusted-Library
+
+If one of these properties is specified, the signatures of the jar files are 
+removed because the jar files are modified.
+
+The [JNLP file can also be signed](http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/signedJNLP.html) 
+if the property ${jarsigner.signJnlpFile} is set to true. The signed JNLP file is
+created in the folder JNLP-INF in the jar jar file of the main class. The file is
+APPLICATION_TEMPLATE.JNLP for a template and is APPLICATION.JNLP if the file is 
+the strict copy of the JNLP file.
+
+If the property ${jarsigner.signJnlpFileWithTemplate} is set to true, the JNLP 
+file is signed with the template defined in the property jnlpSigningTemplate. 
+
+Note that if the JNLP file is not signed, some properties are considered as
+insecure if they are not preceded by the "jnlp."or "javaws." prefix. (Properties
+such as "eclipse.product", "eclipse.application", etc... )
+The properties can be transformed into "secure" ones by adding the "jnlp."-prefix. 
+A custom launcher must be wrote which iterates through all properties and removes 
+the prefix. The custom launcher can be :
+
+```java
+public class WebStartMain
+{
+    public static void main(String[] args)
+    {
+        Properties props = System.getProperties();
+        for (String key : props.stringPropertyNames())
+            if (key.startsWith("jnlp."))
+                System.setProperty(key.substring(5), props.getProperty(key));
+        org.eclipse.equinox.launcher.WebStartMain.main(args);
+    }
+}
+ ```
+
+
+
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <maven-version>3.0</maven-version>
-    <tycho-version>0.13.0</tycho-version>
+    <tycho-version>0.21.0</tycho-version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.sonatype.tycho</groupId>
   <artifactId>tycho-jnlp-plugin</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.3-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <properties>
@@ -47,6 +47,7 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
       <version>1.13</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>de.pdark</groupId>
@@ -61,8 +62,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.sonatype.tycho</groupId>
   <artifactId>tycho-jnlp-plugin</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <properties>

--- a/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
@@ -223,6 +223,13 @@ public class JarsignerMojo
      * The path to the jar we are going to use.
      */
     private String jarExecutable;
+    
+    /**
+     * See <a href="http://java.sun.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * 
+     * @parameter expression="${jarsigner.tsa}"
+     */
+    private String tsa;
 
     public void execute()
         throws MojoExecutionException, MojoFailureException
@@ -551,7 +558,11 @@ public class JarsignerMojo
             commandLine.createArg().setValue( "-digestalg" );
             commandLine.createArg().setValue( this.digestalg );
         }
-        
+        if ( !StringUtils.isEmpty( this.tsa ) )
+        {
+        	commandLine.createArg().setValue( "-tsa" );
+        	commandLine.createArg().setValue( this.tsa );
+        }
 
         commandLine.createArg().setFile( archive );
 

--- a/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
@@ -11,14 +11,21 @@
 
 package org.sonatype.tycho.jnlp;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.Os;
+import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
@@ -27,6 +34,8 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
 import org.eclipse.tycho.core.ArtifactDependencyVisitor;
 import org.eclipse.tycho.core.FeatureDescription;
 import org.eclipse.tycho.core.PluginDescription;
+
+import de.pdark.decentxml.Document;
 
 /**
  * Signs bundle and feature jar files assembled inside target/site folder using jarsigner. This mojo signs all jars,
@@ -39,12 +48,13 @@ import org.eclipse.tycho.core.PluginDescription;
  * @goal sign-jars
  */
 public class JarsignerMojo
-    extends AbstractJnlpMojo
+    extends JnlpFileMojo
 {
 
     private static final String FEATURES_DIR = "features/";
     private static final String PLUGINS_DIR = "plugins/";
-
+    private static final String MANIFEST_FILE = "manifest_file";
+    
     /**
      * See <a href="http://java.sun.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
      * 
@@ -72,6 +82,15 @@ public class JarsignerMojo
      * @parameter expression="${jarsigner.sigfile}"
      */
     private String sigfile;
+
+    /**
+     * See Options for <a href="http://java.sun.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">java 6</a>.
+     * and <a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">java 7</a>.
+     * If this option is not specified,  SHA-1 will be used with java 6, and SHA256 will be used for java 7
+     * 
+     * @parameter expression="${jarsigner.digestalg}"
+     */
+    private String digestalg;
 
     /**
      * See <a href="http://java.sun.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
@@ -110,6 +129,85 @@ public class JarsignerMojo
     private String alias;
 
     /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Permissions Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.permissions}"
+     */
+    private String permissions;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Codebase Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.codebase}"
+     */
+    private String codebase;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Application-Name Attribute </a>.
+     * 
+     * @parameter expression="${jarsigner.applicationName}"
+     */
+    private String applicationName;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Application-Library-Allowable-Codebase Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.applicationLibraryAllowableCodebase}"
+     */
+    private String applicationLibraryAllowableCodebase;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Caller-Allowable-Codebase Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.callerAllowableCodebase}"
+     */
+    private String callerAllowableCodebase;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Trusted-Only Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.trustedOnly}"
+     */
+    private String trustedOnly;
+
+    /**
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">Trusted-Library Attribute</a>.
+     * 
+     * @parameter expression="${jarsigner.trustedLibrary}"
+     */
+    private String trustedLibrary;
+
+    /**
+     * Set to {@code true} to sign the jnlp file
+     * 
+     * @parameter expression="${jarsigner.signJnlpFile}" default-value="false"
+     */
+    private boolean signJnlpFile;
+
+
+    /**
+     * Set to {@code true} to sign the jnlp file with the template instead of the the jnlp file
+     * 
+     * @parameter expression="${jarsigner.signJnlpFileWithTemplate}" default-value="false"
+     */
+    private boolean signJnlpFileWithTemplate;
+
+    /**
+     * @parameter default-value="${project.basedir}/src/main/jnlp/signing_install.jnlp"
+     */
+    private File jnlpSigningTemplate;
+
+    /**
+     * The generated file used to sign the jnlp file
+     */
+    private File jnlpSigningFile;
+
+    /**
+     * The application main class, used to find the jar to use to sign the jnlp file
+     */
+    private String applicationMainClassFile;
+
+    /**
      * Set to {@code true} to disable the plugin.
      * 
      * @parameter expression="${jarsigner.skip}" default-value="true"
@@ -119,113 +217,274 @@ public class JarsignerMojo
     /**
      * The path to the jarsigner we are going to use.
      */
-    private String executable;
+    private String jarsignerExecutable;
+
+    /**
+     * The path to the jar we are going to use.
+     */
+    private String jarExecutable;
 
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-        if ( !this.skip )
+        if ( this.skip )
+            return;
+            
+        this.jarsignerExecutable = getExecutable("jarsigner");
+        this.jarExecutable = getExecutable("jar");
+
+        final ArrayList<Exception> exceptions = new ArrayList<Exception>();
+
+        if ( this.signJnlpFile)
         {
-            this.executable = getExecutable();
+            getLog().info( "  Generating the signed jnlp file" );
+            Document document = loadTemplate( this.signJnlpFileWithTemplate ? 
+                                              this.jnlpSigningTemplate : this.jnlpTemplate);
+            addResources( document.getRootElement() );
+            jnlpSigningFile = new File(jnlpFile.getParent(), "template.jnlp");
+            writeXmlFile( document, jnlpSigningFile );
+            
+            //Find the application main class to find the appropriate jar file to 
+            //sign the jnlp
+            Document documentJnlp = loadTemplate( jnlpTemplate );
+            String mainClass = documentJnlp.getRootElement().getChild("application-desc").getAttribute("main-class").getValue();
+            applicationMainClassFile = mainClass.replace('.', File.separatorChar) + ".class";
+            getLog().info( "  Application main class : " + applicationMainClassFile);
+        }
 
-            final ArrayList<Exception> exceptions = new ArrayList<Exception>();
-
-            getDependencyWalker().walk( new ArtifactDependencyVisitor()
+        getDependencyWalker().walk( new ArtifactDependencyVisitor()
+        {
+            @Override
+            public boolean visitFeature( FeatureDescription feature )
             {
-                @Override
-                public boolean visitFeature( FeatureDescription feature )
+                String id = feature.getKey().getId();
+                String version = getVersion( feature );
+
+                File archive = new File( target, FEATURES_DIR + id + "_" + version + ".jar" );
+
+                if ( archive.isFile() && archive.canWrite() )
                 {
-                    String id = feature.getKey().getId();
-                    String version = getVersion( feature );
-
-                    File archive = new File( target, FEATURES_DIR + id + "_" + version + ".jar" );
-
-                    if ( archive.isFile() && archive.canWrite() )
+                    try
                     {
-                        try
-                        {
-                            signFile( archive );
-                        }
-                        catch ( MojoExecutionException e )
-                        {
-                            getLog().warn( "Could not sign jar", e );
-                            exceptions.add( e );
-                        }
+                        getLog().info( "Jar file :" + archive.getAbsolutePath() );
+                        addSecurityAttributes( archive );
+                        signFile( archive );
                     }
-
-                    return true; // keep visiting
-                }
-
-                @Override
-                public void visitPlugin( PluginDescription plugin )
-                {
-                    String id = plugin.getKey().getId();
-                    String version = getVersion( plugin );
-
-                    File archive = new File( target, PLUGINS_DIR + id + "_" + version + ".jar" );
-
-                    if ( archive.isFile() && archive.canWrite() )
+                    catch ( MojoExecutionException e )
                     {
-                        try
-                        {
-                            signFile( archive );
-                        }
-                        catch ( MojoExecutionException e )
-                        {
-                            getLog().warn( "Could not sign jar", e );
-                            exceptions.add( e );
-                        }
+                        getLog().warn( "Could not add security attributes or sign jar", e );
+                        exceptions.add( e );
                     }
                 }
-            } );
 
-            if ( !exceptions.isEmpty() )
-            {
-                throw new MojoExecutionException( "Could not sign some jar files" );
+                return true; // keep visiting
             }
+
+            @Override
+            public void visitPlugin( PluginDescription plugin )
+            {
+                String id = plugin.getKey().getId();
+                String version = getVersion( plugin );
+
+                File archive = new File( target, PLUGINS_DIR + id + "_" + version + ".jar" );
+
+                if ( archive.isFile() && archive.canWrite() )
+                {
+                    try
+                    {
+                        getLog().info( "Jar file :" + archive.getAbsolutePath() );
+                        addSecurityAttributes( archive );
+                        signFile( archive );
+                    }
+                    catch ( MojoExecutionException e )
+                    {
+                        getLog().warn( "Could not add security attributes or sign jar", e );
+                        exceptions.add( e );
+                    }
+                }
+            }
+        } );
+
+        if ( !exceptions.isEmpty() )
+        {
+            throw new MojoExecutionException( "Could not add security attributes or sign some jar files" );
         }
     }
 
+    /**
+     * Add security attributes to the manifest. 
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/manifest.html">JAR File Manifest Attributes for Security </a>
+     * Since the jar is modified, the signatures are removed from the jar file
+     * before adding the attributes in the manifest.
+     * 
+     * @param The archive file
+     */
+    void addSecurityAttributes( File archive )
+        throws MojoExecutionException
+    {
+        if ( StringUtils.isEmpty( this.permissions ) 
+                && StringUtils.isEmpty( this.codebase ) 
+                && StringUtils.isEmpty( this.applicationName )
+                && StringUtils.isEmpty( this.applicationLibraryAllowableCodebase )
+                && StringUtils.isEmpty( this.callerAllowableCodebase )
+                && StringUtils.isEmpty( this.trustedOnly )
+                && StringUtils.isEmpty( this.trustedLibrary ) )
+            return;
+
+        getLog().info( "  Removing signatures" );
+        File tempFolder = new File(archive.getParentFile(), "temp");
+        if (tempFolder.exists())
+            if( !deleteFolder(tempFolder) )
+                throw new MojoExecutionException( "Cannot delete folder " + tempFolder.getAbsolutePath());
+        if ( !tempFolder.mkdir() )
+            throw new MojoExecutionException( "Cannot create folder " + tempFolder.getAbsolutePath());
+        
+        //unjar in a folder
+        Commandline commandLine = new Commandline();
+        commandLine.setExecutable( this.jarExecutable );
+        commandLine.setWorkingDirectory( tempFolder );
+        commandLine.createArg().setValue( "xf" );
+        commandLine.createArg().setFile( archive );
+        getLog().debug( "Executing: " + commandLine );
+        try
+        {
+            int rc = executeCommandLine( commandLine );
+            if ( rc != 0 )
+                throw new MojoExecutionException( "Could not extract jar " + archive + " (return code " + rc
+                    + "), command line was " + commandLine );
+        }
+        catch ( CommandLineException e )
+        {
+            throw new MojoExecutionException( "Could not extract jar " + archive, e );
+        }
+        
+        //Delete the signature files because the manifest is modified. 
+        for (File file : new File(tempFolder, "META-INF").listFiles())
+            if (file.getName().endsWith(".SF")
+                    || file.getName().endsWith(".DSA")
+                    || file.getName().endsWith(".RSA")
+                    || file.getName().endsWith(".EC"))
+                file.delete();
+        
+        //Recreate the jar file
+        commandLine = new Commandline();
+        commandLine.setExecutable( this.jarExecutable );
+        commandLine.setWorkingDirectory( tempFolder );
+        File metaInfFolder = new File(tempFolder, "META-INF");
+        File manifestFile = new File(metaInfFolder, "MANIFEST.MF");
+        
+        
+        //Add the singed jnlp in the jar of the application main class
+        if ( this.signJnlpFile && new File(tempFolder, applicationMainClassFile).exists())
+        {
+            getLog().info( "  Adding jnlp file signature to " + archive.getName());
+            File jnlpInfFolder = new File(tempFolder, "JNLP-INF");
+            if ( !jnlpInfFolder.mkdir() )
+                throw new MojoExecutionException( "Cannot create folder " + jnlpInfFolder.getAbsolutePath());
+            
+            try
+            {
+                Files.copy(this.jnlpSigningFile.toPath(), 
+                            new File(jnlpInfFolder, this.signJnlpFileWithTemplate ? 
+                                     "APPLICATION_TEMPLATE.JNLP" : "APPLICATION.JNLP").toPath());
+            }
+            catch ( IOException e )
+            {
+                throw new MojoExecutionException( "Could not copy the jar file to sign " + archive, e );
+            }
+        }
+        
+        if ( manifestFile.exists())
+        {
+            commandLine.createArg().setValue( "cfm" );
+            commandLine.createArg().setFile( archive );
+            commandLine.createArg().setFile( manifestFile );
+        }
+        else
+        {
+            commandLine.createArg().setValue( "cf" );
+            commandLine.createArg().setFile( archive );
+        }
+        for (File file : tempFolder.listFiles())
+            commandLine.createArg().setValue( file.getName() );
+        getLog().debug( "Executing: " + commandLine );
+        try
+        {
+            int rc = executeCommandLine( commandLine);
+            if ( rc != 0 )
+                throw new MojoExecutionException( "Could not recreate jar " + archive + " (return code " + rc
+                    + "), command line was " + commandLine );
+        }
+        catch ( CommandLineException e )
+        {
+            throw new MojoExecutionException( "Could not recreate jar " + archive, e );
+        }
+        if( !deleteFolder(tempFolder) )
+            throw new MojoExecutionException( "Cannot delete folder " + tempFolder.getAbsolutePath());
+        
+        getLog().info( "  Adding security attributes" );
+        
+        commandLine = new Commandline();
+        commandLine.setExecutable( this.jarExecutable );
+        commandLine.setWorkingDirectory( this.project.getBasedir() );
+
+        StringBuffer content = new StringBuffer();
+        if ( !StringUtils.isEmpty( this.permissions ) )
+            content.append(String.format("Permissions: %s\n", this.permissions));
+        if ( !StringUtils.isEmpty( this.codebase ) )
+            content.append(String.format("Codebase: %s\n", this.codebase));
+        if ( !StringUtils.isEmpty( this.applicationName ) )
+            content.append(String.format("Application-Name: %s\n", this.applicationName));
+        if ( !StringUtils.isEmpty( this.applicationLibraryAllowableCodebase ) )
+            content.append(String.format("Application-Library-Allowable-Codebase: %s\n", this.applicationLibraryAllowableCodebase));
+        if ( !StringUtils.isEmpty( this.callerAllowableCodebase ) )
+            content.append(String.format("Caller-Allowable-Codebase: %s\n", this.callerAllowableCodebase));
+        if ( !StringUtils.isEmpty( this.trustedOnly ) )
+            content.append(String.format("Trusted-Only: %s\n", this.trustedOnly));
+        if ( !StringUtils.isEmpty( this.trustedLibrary ) )
+            content.append(String.format("Trusted-Library: %s\n", this.trustedLibrary));
+
+        File inputManifestFile = new File(archive.getParentFile(), MANIFEST_FILE);
+        writeFile(inputManifestFile, content.toString());
+        commandLine.createArg().setValue( "ufm" );
+        commandLine.createArg().setFile( archive );
+        commandLine.createArg().setFile( inputManifestFile );
+        getLog().debug( "Executing: " + commandLine );
+        
+        try
+        {
+            int rc = executeCommandLine( commandLine);
+            if ( rc != 0 )
+                throw new MojoExecutionException( "Could not add security attributes to jar " + archive + " (return code " + rc
+                    + "), command line was " + commandLine );
+        }
+        catch ( CommandLineException e )
+        {
+            throw new MojoExecutionException( "Could not add security attributes to jar " + archive, e );
+        }
+    }
+
+    /**
+     * Sign file
+     * 
+     * @param The archive file to be signed
+     */
     void signFile( File archive )
         throws MojoExecutionException
     {
-        getLog().info( "Executing jarsigner on " + archive.getAbsolutePath() );
+        getLog().info( "  Signing jar file" );
 
         Commandline commandLine = new Commandline();
-
-        commandLine.setExecutable( this.executable );
-
+        commandLine.setExecutable( this.jarsignerExecutable );
         commandLine.setWorkingDirectory( this.project.getBasedir() );
-
         commandLine = getCommandline( archive, commandLine );
-
         getLog().debug( "Executing: " + commandLine );
-
-        StreamConsumer out = new StreamConsumer()
-        {
-            public void consumeLine( String line )
-            {
-                getLog().debug( line );
-            }
-        };
-
-        StreamConsumer err = new StreamConsumer()
-        {
-            public void consumeLine( String line )
-            {
-                getLog().warn( line );
-            }
-        };
-
         try
         {
-            int rc = CommandLineUtils.executeCommandLine( commandLine, out, err );
-
+            int rc = executeCommandLine( commandLine );
             if ( rc != 0 )
-            {
                 throw new MojoExecutionException( "Could not sign jar " + archive + " (return code " + rc
                     + "), command line was " + commandLine );
-            }
         }
         catch ( CommandLineException e )
         {
@@ -287,6 +546,12 @@ public class JarsignerMojo
             commandLine.createArg().setValue( "-sigfile" );
             commandLine.createArg().setValue( this.sigfile );
         }
+        if ( !StringUtils.isEmpty( this.digestalg ) )
+        {
+            commandLine.createArg().setValue( "-digestalg" );
+            commandLine.createArg().setValue( this.digestalg );
+        }
+        
 
         commandLine.createArg().setFile( archive );
 
@@ -299,14 +564,102 @@ public class JarsignerMojo
     }
 
     /**
+     * Execute a command line
+     * 
+     * @return The return value of the command.
+     */
+    private int executeCommandLine( Commandline commandLine )
+        throws CommandLineException
+    {
+        StreamConsumer out = new StreamConsumer()
+        {
+            public void consumeLine( String line )
+            {
+                getLog().debug( line );
+            }
+        };
+
+        StreamConsumer err = new StreamConsumer()
+        {
+            public void consumeLine( String line )
+            {
+                getLog().warn( line );
+            }
+        };
+
+        return CommandLineUtils.executeCommandLine( commandLine, out, err );
+    }
+
+    /**
+     * Write the input manifest file 
+     * 
+     * @param file The file to write
+     * @param content The Content
+     */
+   protected void writeFile(File file, String content)
+                 throws MojoExecutionException
+    {
+        try
+        {
+            OutputStream os = new BufferedOutputStream(new FileOutputStream(
+                    file));
+            try
+            {
+                OutputStreamWriter writer = new OutputStreamWriter(os, "UTF-8");
+                try
+                {
+                    writer.write(content);
+                }
+                finally
+                {
+                    writer.flush();
+                }
+            }
+            finally
+            {
+                IOUtil.close(os);
+            }
+        }
+        catch (IOException e)
+        {
+            throw new MojoExecutionException("Could not write output file "
+                                           + file.getAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Delete directory file
+     * 
+     * @param path
+     *            The directory
+     * @return true if ok
+     */
+    private boolean deleteFolder(File path)
+    {
+        if (path.isDirectory() && path.exists())
+        {
+            File[] files = path.listFiles();
+            for (int i = 0; i < files.length; i++)
+            {
+                if (files[i].isDirectory())
+                    deleteFolder(files[i]);
+                else
+                    files[i].delete();
+            }
+        }
+        return (path.delete());
+    }
+
+
+    /**
      * Locates the executable for the jarsigner tool.
      * 
      * @Copy&paste from org.apache.maven.plugins.jarsigner.AbstractJarsignerMojo
      * @return The executable of the jarsigner tool, never <code>null<code>.
      */
-    private String getExecutable()
+    private String getExecutable(String name)
     {
-        String command = "jarsigner" + ( Os.isFamily( Os.FAMILY_WINDOWS ) ? ".exe" : "" );
+        String command = name + ( Os.isFamily( Os.FAMILY_WINDOWS ) ? ".exe" : "" );
 
         String executable =
             findExecutable( command, System.getProperty( "java.home" ), new String[] { "../bin", "bin", "../sh" } );

--- a/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
@@ -386,8 +386,11 @@ public class JarsignerMojo
         {
             getLog().info( "  Adding jnlp file signature to " + archive.getName());
             File jnlpInfFolder = new File(tempFolder, "JNLP-INF");
-            if ( !jnlpInfFolder.mkdir() )
-                throw new MojoExecutionException( "Cannot create folder " + jnlpInfFolder.getAbsolutePath());
+            if ( !jnlpInfFolder.exists())
+            {
+            	if ( !jnlpInfFolder.mkdir() )
+            		throw new MojoExecutionException( "Cannot create folder " + jnlpInfFolder.getAbsolutePath());
+            }
             
             try
             {

--- a/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JarsignerMojo.java
@@ -20,12 +20,11 @@ import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Properties;
-import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
@@ -627,6 +626,7 @@ public class JarsignerMojo
                 finally
                 {
                     writer.flush();
+                    writer.close();
                 }
             }
             finally

--- a/src/main/java/org/sonatype/tycho/jnlp/JnlpFileMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JnlpFileMojo.java
@@ -36,7 +36,7 @@ import org.eclipse.tycho.core.ArtifactDependencyVisitor;
 import org.eclipse.tycho.core.PluginDescription;
 import org.eclipse.tycho.model.PluginRef;
 import org.eclipse.tycho.model.ProductConfiguration;
-import org.eclipse.tycho.core.utils.PlatformPropertiesUtils;
+import org.eclipse.tycho.core.resolver.shared.PlatformPropertiesUtils;
 
 import de.pdark.decentxml.Document;
 import de.pdark.decentxml.Element;

--- a/src/main/java/org/sonatype/tycho/jnlp/JnlpFileMojo.java
+++ b/src/main/java/org/sonatype/tycho/jnlp/JnlpFileMojo.java
@@ -92,13 +92,13 @@ public class JnlpFileMojo
     /**
      * @parameter default-value="${project.basedir}/src/main/jnlp/install.jnlp"
      */
-    private File jnlpTemplate;
+    protected File jnlpTemplate;
 
     /**
      * @parameter 
      *            default-value="${project.build.directory}/product/eclipse/${project.artifactId}_${unqualifiedVersion}.jnlp"
      */
-    private File jnlpFile;
+    protected File jnlpFile;
 
     /**
      * Maps environment key (i.e. osgi os/ws/arch) to Java os.name and os.arch system properties values.
@@ -126,9 +126,7 @@ public class JnlpFileMojo
         throws MojoExecutionException, MojoFailureException
     {
         Document document = loadTemplate( jnlpTemplate );
-
         addResources( document.getRootElement() );
-
         writeXmlFile( document, jnlpFile );
     }
 


### PR DESCRIPTION
Add -digestalg for jarsigner, default algorithm changed for jarsigner in jdk7. 
Add options for JAR file manifest attributes for security (Permissions, Codebase, etc... ) and delete precedent signatures. 
Add possibility to sign the JNLP file into the main jar file. A JNLP template file can be used.
